### PR TITLE
Migrate ConfigStandardDoclet.java to JDK11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
 
     <clover.license>${user.home}/clover.license</clover.license>
     <guava.version>31.1-jre</guava.version>
-    <hadoop.version>3.3.1</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <netty.version>4.1.72.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>

--- a/tez-dag/src/main/java/org/apache/tez/state/StateMachineTez.java
+++ b/tez-dag/src/main/java/org/apache/tez/state/StateMachineTez.java
@@ -51,6 +51,11 @@ public class StateMachineTez<STATE extends Enum<STATE>, EVENTTYPE extends Enum<E
     return realStatemachine.getCurrentState();
   }
 
+  public STATE getPreviousState() {
+    return realStatemachine.getPreviousState();
+  }
+
+
   @SuppressWarnings("unchecked")
   @Override
   public STATE doTransition(EVENTTYPE eventType, EVENT event) throws

--- a/tez-dag/src/main/java/org/apache/tez/state/StateMachineTez.java
+++ b/tez-dag/src/main/java/org/apache/tez/state/StateMachineTez.java
@@ -51,12 +51,6 @@ public class StateMachineTez<STATE extends Enum<STATE>, EVENTTYPE extends Enum<E
     return realStatemachine.getCurrentState();
   }
 
-  @Override
-  public STATE getPreviousState() {
-    return realStatemachine.getPreviousState();
-  }
-
-
   @SuppressWarnings("unchecked")
   @Override
   public STATE doTransition(EVENTTYPE eventType, EVENT event) throws

--- a/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/doclet/ConfigStandardDoclet.java
+++ b/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/doclet/ConfigStandardDoclet.java
@@ -37,7 +37,6 @@ import org.apache.tez.tools.javadoc.model.ConfigProperty;
 import org.apache.tez.tools.javadoc.util.HtmlWriter;
 import org.apache.tez.tools.javadoc.util.XmlWriter;
 
-import jdk.javadoc.doclet.Doclet;
 import jdk.javadoc.doclet.StandardDoclet;
 import jdk.javadoc.doclet.DocletEnvironment;
 import jdk.javadoc.doclet.Reporter;
@@ -46,12 +45,11 @@ public class ConfigStandardDoclet extends StandardDoclet {
 
   private static final String DEBUG_SWITCH = "-debug";
   private static boolean debugMode = false;
-  private DocletEnvironment docEnv;
-  private Reporter reporter;
+  private static DocletEnvironment docEnv;
+
 
   public void init(DocletEnvironment docEnv, Reporter reporter) {
-    this.docEnv = docEnv;
-    this.reporter = reporter;
+    ConfigStandardDoclet.docEnv = docEnv;
   }
 
   private static void logMessage(String message) {
@@ -63,7 +61,7 @@ public class ConfigStandardDoclet extends StandardDoclet {
 
   @Override
   public boolean run(DocletEnvironment docEnv) {
-    this.docEnv = docEnv;
+    ConfigStandardDoclet.docEnv = docEnv;
 
     for (Element element : docEnv.getSpecifiedElements()) {
       if (element.getKind() == ElementKind.CLASS) {
@@ -73,7 +71,7 @@ public class ConfigStandardDoclet extends StandardDoclet {
     return true;
   }
 
-  private void processDoc(TypeElement doc) {
+  private static void processDoc(TypeElement doc) {
     logMessage("Parsing : " + doc);
     if (doc.getKind() != ElementKind.CLASS) {
       logMessage("Ignoring non-class: " + doc);
@@ -200,7 +198,7 @@ public class ConfigStandardDoclet extends StandardDoclet {
     }
   }
 
-  private String getDocComment(Element element) {
+  private static String getDocComment(Element element) {
     return docEnv.getElementUtils().getDocComment(element);
   }
 
@@ -211,14 +209,14 @@ public class ConfigStandardDoclet extends StandardDoclet {
     return s;
   }
 
-  public int optionLength(String option) {
+  public static int optionLength(String option) {
     if (option.equals(DEBUG_SWITCH)) {
       return 1;
     }
     return 0;
   }
 
-  public boolean validOptions(String[][] options, Reporter reporter) {
+  public static boolean validOptions(String[][] options, Reporter reporter) {
     for (String[] opt : options) {
       for (String o : opt) {
         if (o.equals(DEBUG_SWITCH)) {

--- a/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/doclet/ConfigStandardDoclet.java
+++ b/tez-tools/tez-javadoc-tools/src/main/java/org/apache/tez/tools/javadoc/doclet/ConfigStandardDoclet.java
@@ -22,10 +22,7 @@ import java.io.IOException;
 import java.util.Map;
 
 import javax.lang.model.element.*;
-import javax.lang.model.util.Elements;
 import javax.lang.model.util.ElementFilter;
-import javax.tools.Diagnostic;
-import javax.tools.JavaFileObject;
 
 import org.apache.hadoop.classification.InterfaceAudience.Private;
 import org.apache.hadoop.classification.InterfaceStability.Evolving;


### PR DESCRIPTION
Change to move `org.apache.tez.tools.javadoc.doclet.ConfigStandardDoclet.java` from using  `com.sun.tools.doclets.standard`  to  JDK11 Javadoc syntax