### PR TITLE
OSV-17377 - CVE - Increasing netty version to 4.1.133.Final (netty-bom) to fix the Tez netty CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <guava.version>32.0.1-jre</guava.version>
     <hadoop.version>3.2.3.3.2.3.7-2</hadoop.version>
     <mockito-core.version>4.3.1</mockito-core.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.133.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <jersey.version>1.19</jersey.version>
     <slf4j.version>1.7.35</slf4j.version>
@@ -334,6 +334,13 @@
         <groupId>commons-lang</groupId>
         <artifactId>commons-lang</artifactId>
         <version>2.6</version>
+      </dependency>
+      <dependency>
+        <groupId>io.netty</groupId>
+        <artifactId>netty-bom</artifactId>
+        <version>${netty.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>io.netty</groupId>


### PR DESCRIPTION
- Tickets : OSV-17377, OSV-17310, OSV-17307, OSV-17303, OSV-17298, OSV-17297, OSV-17296, OSV-17295, OSV-17294, OSV-17293, OSV-17282

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.