### PR TITLE
OSV-17281 - CVE - Increasing tez jackson version to 2.18.6 to fix the Tez jackson CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,8 +66,8 @@
     <slf4j.version>1.7.35</slf4j.version>
     <jackson.codehaus.version.hadoop>1.9.2</jackson.codehaus.version.hadoop> <!-- transitive, used by hadoop in tests -->
     <jackson.version.hadoop>2.16.1</jackson.version.hadoop> <!-- transitive, used by hadoop in tests -->
-    <jackson.core.version.tez>2.16.1</jackson.core.version.tez> <!-- core, used in tez -->
-    <jackson.databind.version.tez>2.16.1</jackson.databind.version.tez> <!-- databind, used in tez -->
+    <jackson.core.version.tez>2.18.6</jackson.core.version.tez> <!-- core, used in tez -->
+    <jackson.databind.version.tez>2.18.6</jackson.databind.version.tez> <!-- databind, used in tez -->
     <protobuf.version>2.5.0</protobuf.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <protoc.path>${env.PROTOC_PATH}</protoc.path>


### PR DESCRIPTION
- Tickets : OSV-17281

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.