### PR TITLE
OSV-17290 - CVE - Increasing commons-io version to 2.14.0 to fix the Tez commons-io CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -328,7 +328,7 @@
       <dependency>
         <groupId>commons-io</groupId>
         <artifactId>commons-io</artifactId>
-        <version>2.8.0</version>
+        <version>2.14.0</version>
       </dependency>
       <dependency>
         <groupId>commons-lang</groupId>


### PR DESCRIPTION
- Tickets : OSV-17290

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.