### PR TITLE
OSV-17305 - CVE - Increasing async-http-client version to 2.15.0 to fix the Tez async-http-client CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -269,7 +269,7 @@
       <dependency>
         <groupId>org.asynchttpclient</groupId>
         <artifactId>async-http-client</artifactId>
-        <version>2.12.4</version>
+        <version>2.15.0</version>
         <exclusions>
           <exclusion>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
- Tickets : OSV-17305, OSV-17304

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.