### PR TITLE
OSV-17283 - CVE - Pinning commons-configuration2 to 2.15.0 to fix the Tez commons-configuration2 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
         <version>2.6</version>
       </dependency>
       <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>2.15.0</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <scope>compile</scope>


### PR DESCRIPTION
- Tickets : OSV-17283

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.