### PR TITLE
OSV-17368 - CVE - Pinning okio to 1.17.6 to fix the Tez okio CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
         <version>2.6</version>
       </dependency>
       <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>1.17.6</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <scope>compile</scope>


### PR DESCRIPTION
- Tickets : OSV-17368

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.