### PR TITLE
OSV-17311 - CVE - Pinning jdom2 to 2.0.6.1 to fix the Tez jdom2 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,11 @@
         <version>2.6</version>
       </dependency>
       <dependency>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom2</artifactId>
+        <version>2.0.6.1</version>
+      </dependency>
+      <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>
         <scope>compile</scope>


### PR DESCRIPTION
- Tickets : OSV-17311

Tez 3.2.3.6 CVE per-library fix. Verified to resolve cleanly across the reactor via `mvn dependency:tree` on JDK 8.