### PR TITLE
OSV-23227: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <maven-site-plugin.version>2.4</maven-site-plugin.version>
     <metrics-core.version>3.1.0</metrics-core.version>
     <mockito-core.version>4.3.1</mockito-core.version>
-    <netty.version>4.1.132.Final</netty.version>
+    <netty.version>4.1.135.Final</netty.version>
     <pig.version>0.13.0</pig.version>
     <protobuf.version>3.25.5</protobuf.version>
     <snappy-java.version>1.1.10.4</snappy-java.version>


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (12)
OSV-23227, OSV-23228, OSV-23229, OSV-23230, OSV-23231, OSV-23232, OSV-23235, OSV-23237, OSV-23254, OSV-23255, OSV-23256, OSV-23262
