### PR TITLE
OSV-23253 - CVE - Bumped-up Jackson to 2.18.6 to address GHSA-72hv-8253-57qq

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,9 @@
   </organization>
 
   <properties>
+        <jackson.databind.version.tez>2.18.6</jackson.databind.version.tez>
+        <jackson.core.version.tez>2.18.6</jackson.core.version.tez>
+        <jackson.version>2.18.6</jackson.version>
     <!-- Build Properties -->
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-23253, OSV-23259, OSV-23260, OSV-23261