### PR TITLE
OSV-23224 - CVE - Bumped-up async-http-client 2.15.0, okio 3.4.0, commons-configuration2 2.15.0 to address ODP 3.3.6.4 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <distMgmtStagingUrl>https://repository.apache.org/service/local/staging/deploy/maven2</distMgmtStagingUrl>
 
     <!--dependency versions in alphabetical order-->
-    <asynchttpclient.version>2.12.4</asynchttpclient.version>
+    <asynchttpclient.version>2.15.0</asynchttpclient.version>
     <bouncycastle.version>1.78</bouncycastle.version>
     <build-helper-maven-plugin.version>1.8</build-helper-maven-plugin.version>
     <buildnumber-maven-plugin.version>1.1</buildnumber-maven-plugin.version>
@@ -325,6 +325,24 @@
         <artifactId>commons-lang</artifactId>
         <version>${commons-lang.version}</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-configuration2</artifactId>
+        <version>2.15.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio-jvm</artifactId>
+        <version>3.4.0</version>
+      </dependency>
+
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-all</artifactId>


### PR DESCRIPTION
- Component: tez (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Tickets: OSV-23224, OSV-23236, OSV-23242, OSV-23243
- Bumps:
  - async-http-client: -> 2.15.0
  - okio/okio-jvm: -> 3.4.0
  - commons-configuration2: -> 2.15.0